### PR TITLE
Add case sensitive tokens

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,10 +51,13 @@ color = "#ff5f5f"
 
 [[olli.tokens]]
 token = "INFO"
+case_sensitive = true
 # When no color is provided it falls back to blurple.
 ```
 
 Tokens accept a `token` and `color` key, the first one is required. `token` represents the phrase that should be searched for and `color` is a hex color (**with** hashtag) that will be used for the generated embeds.
+
+Tokens also accept a `case_sensitive` key which defaults to `false`. If you want to match the case as written in the `token` field set `case_sensitive` to `true` in the token config.
 
 ## `loki`
 
@@ -94,6 +97,7 @@ color = "#ff5f5f"
 [[olli.tokens]]
 token = "WARN"
 color = "#ffe24d"
+case_sensitive = true
 
 [[olli.tokens]]
 token = "INFO"

--- a/olli/alert.py
+++ b/olli/alert.py
@@ -14,7 +14,7 @@ def get_match(token: TokenConfig) -> TokenMatch:
     """Search the configured service logs for a given token."""
     try:
         logger.debug(f"Searching for token {token.token}")
-        svc_logs = api_client.get_token_logs(token.token)
+        svc_logs = api_client.get_token_logs(token)
     except httpx.ConnectError:
         logger.error("Could not connect to Loki")
         return webhook.send_olli_error("Loki refused to connect.")

--- a/olli/api.py
+++ b/olli/api.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import httpx
 
-from olli.config import CONFIG
+from olli.config import CONFIG, TokenConfig
 
 
 class LokiHTTPClient:
@@ -15,7 +15,7 @@ class LokiHTTPClient:
         """Generate the Loki API route for a given path."""
         return CONFIG.loki.api_url + "/loki/api/v1/" + path
 
-    def get_token_logs(self, token: str) -> dict[str, Any]:
+    def get_token_logs(self, token: TokenConfig) -> dict[str, Any]:
         """
         Fetch the logs from configured services for a matchign token.
 
@@ -28,8 +28,10 @@ class LokiHTTPClient:
 
         job_regex = "|".join(CONFIG.loki.jobs)
 
+        case_filter = '(?i)' if not token.case_sensitive else ''
+
         resp = httpx.get(self.route("query_range"), params={
-            "query": f'{{job=~"({job_regex})"}} |~ "(?i){token}"',
+            "query": f'{{job=~"({job_regex})"}} |~ "{case_filter}{token.token}"',
             "start": f"{start_ts:0.0f}",
             "limit": CONFIG.loki.max_logs
         })

--- a/olli/config.py
+++ b/olli/config.py
@@ -24,7 +24,8 @@ class TokenConfig(BaseModel):
     """Class representing a token config entry."""
 
     token: str
-    color: str = "#7289DA"
+    color: Optional[str] = "#7289DA"
+    case_sensitive: Optional[bool] = False
 
 
 class LokiConfig(BaseModel):


### PR DESCRIPTION
Users may want certain tokens to be case sensitive and only trigger as written exactly in the token configuration.

This PR implements a case sensitive flag for users to specify which forces matches to be exact.