### PR TITLE
Ensure tag name is correct format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ jobs:
       version: ${{ steps.get_version.outputs.version }}
 
     steps:
+    - name: Ensure tag is in format v*.*.*
+      run: "[[ ${{ github.event.tag_name }} == v*.*.* ]]"
+
     - name: Get the version
       id: get_version
       run: echo ::set-output name=version::${GITHUB_REF#refs/tags/v}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "olli"
-version = "0.1.0"
+version = "0.1.1"
 description = "Olli searches your Loki logs and relays matching terms to Discord."
 authors = ["Joe Banks <joseph@josephbanks.me>"]
 license = "MIT"


### PR DESCRIPTION
Validates that released versions match `v*.*.*` before attempting deployment.