### PR TITLE
Update Release workflow with correct event reference

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Ensure tag is in format v*.*.*
-      run: "[[ ${{ github.event.tag_name }} == v*.*.* ]]"
+      run: "[[ ${{ github.event.release.tag_name }} == v*.*.* ]]"
 
     - name: Get the version
       id: get_version


### PR DESCRIPTION
Switch from `github.event.tag_name` to `github.event.release.tag_name`.