### PR TITLE
Prevent Loki failures from cascading into Discord failures

### DIFF
--- a/olli/alert.py
+++ b/olli/alert.py
@@ -58,7 +58,8 @@ def run() -> None:
     matches = []
 
     for token in CONFIG.olli.tokens:
-        matches.append(get_match(token))
+        if match := get_match(token):
+            matches.append(match)
 
     send_alerts(matches)
     logger.info("Olli search complete.")


### PR DESCRIPTION
This PR prevents a failure connecting to Loki from cascading into a failure sending to Discord. When a Loki failure occures and `None` is returned by `get_match` then passing it off to the Discord alerter causes attribute errors since it treats it as a match.